### PR TITLE
Changed opacity of hovering stones to differentiate from placed stones

### DIFF
--- a/client/templates/match/board/eventHandlers.js
+++ b/client/templates/match/board/eventHandlers.js
@@ -53,7 +53,11 @@ addEventHandlers = function(board, game) {
         // if it's on the board and it's a valid move (no existing piece)
         if (game.wgoGame.isOnBoard(x, y) && game.wgoGame.isValid(x,y)) {
           // add new object
-          var newObj = { x: x, y: y, c: game.wgoGame.turn };
+          if (game.wgoGame.turn === WGo.B) {
+            var newObj = { x: x, y: y, type: "BLACK_HOVER" };
+          } else {
+            var newObj = { x: x, y: y, type: "WHITE_HOVER" };
+          }
           board.addObject(newObj);
           Session.set("hoverStone"+game._id, newObj);
         }

--- a/lib/wgo.js
+++ b/lib/wgo.js
@@ -494,6 +494,53 @@ Board.drawHandlers = {
 		}
 	},
 
+	// 50% opacity stone for hovering
+	BLACK_HOVER: {
+		stone: {
+			draw: function(args, board) {
+				var xr = board.getX(args.x),
+					yr = board.getY(args.y),
+					sr = board.stoneRadius,
+					radgrad;
+
+				radgrad = this.createRadialGradient(xr-2*sr/5,yr-2*sr/5,1,xr-sr/5,yr-sr/5,4*sr/5);
+				radgrad.addColorStop(0, 'rgba(102, 102, 102, 0.7)');
+				radgrad.addColorStop(1, 'rgba(0, 0, 0, 0.7)');
+
+				// paint stone
+				this.beginPath();
+				this.fillStyle = radgrad;
+				this.arc(xr-0.5, yr-0.5, sr-0.5, 0, 2*Math.PI, true);
+				this.fill();
+			}
+		},
+	},
+
+
+	// 50% opacity stone for hovering
+	WHITE_HOVER: {
+		stone: {
+			draw: function(args, board) {
+				var xr = board.getX(args.x),
+					yr = board.getY(args.y),
+					sr = board.stoneRadius,
+					radgrad;
+
+				// set stone texture
+				radgrad = this.createRadialGradient(xr-2*sr/5,yr-2*sr/5,sr/3,xr-sr/5,yr-sr/5,5*sr/5);
+				radgrad.addColorStop(0, 'rgba(255, 255, 255, 0.7)');
+				//radgrad.addColorStop(1, '#d4d4d4');
+				radgrad.addColorStop(1, 'rgba(170, 170, 170, 0.7)');
+
+				// paint stone
+				this.beginPath();
+				this.fillStyle = radgrad;
+				this.arc(xr-0.5, yr-0.5, sr-0.5, 0, 2*Math.PI, true);
+				this.fill();
+			}
+		},
+	},
+
 	outline: {
 		stone: {
 			draw: function(args, board) {


### PR DESCRIPTION
Ended up being easier than anticipated to change opacity to 70%. Added objects to WGo.Board to implement this. Resolves #77.