### PR TITLE
Fix timer mechanism quirks

### DIFF
--- a/client/templates/lobby/gameRow.js
+++ b/client/templates/lobby/gameRow.js
@@ -22,6 +22,9 @@ Template.gameRow.events({
 
 Template.gameRow.helpers({
   timeString: function() {
-    if (this.isTimed()) return timeDisplay(this.gameLength, 'letters');
+    if (!this.isTimed()) return false;
+
+    this.checkTimerFlag();
+    return timeDisplay(this.gameLength, 'letters');
   }
 });

--- a/client/templates/match/playerBox/gameTimer.js
+++ b/client/templates/match/playerBox/gameTimer.js
@@ -12,10 +12,9 @@ Template.gameTimer.helpers({
 
     if (timeRemaining > 0 || timeRemaining === 0) {
 
-      if (timeRemaining === 0 && !game.archived)
-        Meteor.call("game/endOnTime", game._id, color);
-
+      game.checkTimerFlag();
       return timeDisplay(timeRemaining);
+
     } else return false;
   }
 });

--- a/client/templates/yourGames/yourGameRow.js
+++ b/client/templates/yourGames/yourGameRow.js
@@ -34,18 +34,13 @@ Template.yourGameRow.helpers({
   },
   timeLeft: function() {
     var game = Games.findOne(this._id);
-
     if (!game.isTimed()) return false;
 
     var color = game.getColorOfPlayerId(Meteor.userId());
-
     var timeRemaining = game.timeRemaining(color);
 
     if (timeRemaining > 0 || timeRemaining === 0) {
-
-      if (timeRemaining === 0 && !game.archived)
-        Meteor.call("game/endOnTime", game._id, color);
-
+      game.checkTimerFlag();
       return timeDisplay(timeRemaining);
     } else return false;
 

--- a/lib/methods/games.js
+++ b/lib/methods/games.js
@@ -10,7 +10,7 @@ Meteor.methods({
     var wgoGame = new WGo.Game(gameAttributes.size);
 
     var game = _.extend(gameAttributes, {
-      gameCreated: new Date(),
+      createdAt: new Date(),
       lastActivityAt: new Date(),
       wgoGame: wgoGame.exportPositions(),
     });

--- a/lib/models/game.js
+++ b/lib/models/game.js
@@ -234,7 +234,7 @@ _.extend(Game.prototype, {
     if (this.isTimed()) {
       // we've already played move, so get the opposite color of turn
       var color = getOppositeColor( this.getColorOfCurrentMove() );
-      var now = (Meteor.isClient) ? TimeSync.serverTime() : new Date;
+      var now = (Meteor.isClient) ? new Date(TimeSync.serverTime()) : new Date;
       set = _.extend(set, { lastMoveAt: now });
       set['timeUsed.'+color] = this.timeUsed[color] + this.timeSinceLastMove();
     }
@@ -302,7 +302,7 @@ _.extend(Game.prototype, {
 
     // if this has a timer, update the last move timer to current time
     if (this.isTimed()){
-      var now = (Meteor.isClient) ? TimeSync.serverTime() : new Date;
+      var now = (Meteor.isClient) ? new Date(TimeSync.serverTime()) : new Date;
       data = _.extend(data, { $set: { lastMoveAt: now } });
     }
 
@@ -366,12 +366,15 @@ _.extend(Game.prototype, {
     if (!this.hasPlayer(user)) return false;
 
     // if it's other person's turn, or if we're markingDead
-    if (this.getColorOfCurrentMove() !== color || this.markingDead()) {
-
+    if (this.getColorOfCurrentMove() !== color || this.markingDead())
       return this.gameLength - this.timeUsed[color];
 
-    } else { // if it's this person's turn (and not in MD)
+    // if it's the first move in the game
+    else if (!this.timerIsRunning())
+      return this.gameLength;
 
+    // if it's this person's turn and timer is running
+    else {
       var remaining = this.gameLength - this.timeUsed[color] - this.timeSinceLastMove();
       return (remaining < 0) ? 0 : remaining;
     }
@@ -387,7 +390,7 @@ _.extend(Game.prototype, {
   // return duration since the last activity (in ms)
   timeSinceLastMove: function() {
     if (!this.isTimed()) return false;
-    var now = (Meteor.isClient) ? TimeSync.serverTime() : new Date;
+    var now = (Meteor.isClient) ? new Date(TimeSync.serverTime()) : new Date;
     return moment(now) - moment(this.lastMoveAt);
   },
 

--- a/lib/models/game.js
+++ b/lib/models/game.js
@@ -36,6 +36,7 @@ _.extend(Game.prototype, {
     return true;
   },
 
+  // end game because someone ran out of time
   endGameOnTime: function(color) {
     var user = this.getPlayerAtColor(color);
 
@@ -64,6 +65,22 @@ _.extend(Game.prototype, {
 
     }
 
+  },
+
+  // check both sides' timers and end game if it's flagged
+  checkTimerFlag: function() {
+    var game = this;
+    if (!game.isTimed() || !game.isReady()) return false;
+
+    var whiteTimeRemaining = game.timeRemaining("white");
+    var blackTimeRemaining = game.timeRemaining("black");
+
+    if (game.timeRemaining("white") === 0)
+      Meteor.call("game/endOnTime", game._id, "white");
+    else if (game.timeRemaining("black") === 0)
+      Meteor.call("game/endOnTime", game._id, "black");
+
+    return true;
   },
 
   resign: function() {
@@ -383,7 +400,6 @@ _.extend(Game.prototype, {
   // (has both players, not archived, not marking dead)
   isReady: function() {
     if (
-      !this.wgoGame ||
       this.archived ||
       this.markingDead()
     ) return false;
@@ -518,7 +534,6 @@ _.extend(Game.prototype, {
 
   // get the color of the current turn
   getColorOfCurrentMove: function() {
-    if (!this.wgoGame) return false;
     if (this.archived || !this.isReady()) return false;
     if (this.wgoGame.turn === 1) return "black";
     else if (this.wgoGame.turn === -1) return "white";


### PR DESCRIPTION
Resolves #84:
* Game automatically ends at 0 whenever it's visible anywhere (including lobby or match), not just when you're observing the timer
* Fixed issue where timer would sometimes be off by 1 second before timer starts
* changed gameCreated property to createdAt (fixing ordering in Open Games)