### PR TITLE
Added web notifications to challenges

### DIFF
--- a/client/templates/menu/notificationsMenu/notificationsMenu.js
+++ b/client/templates/menu/notificationsMenu/notificationsMenu.js
@@ -1,3 +1,12 @@
+Template.notificationsMenu.onRendered(function(){
+  this.autorun(function() {
+    if (Session.get("challengeMenuOpen")) {
+      $("#notifications-menu").dropdown("toggle");
+      Session.set("challengeMenuOpen", undefined);
+    }
+  })
+});
+
 Template.notificationsMenu.helpers({
   notifications: function() {
     return Herald.getNotifications({medium: 'onsite'});

--- a/lib/collections/users.js
+++ b/lib/collections/users.js
@@ -109,7 +109,7 @@ Meteor.users.helpers({
 
     if ([ "yourTurn", "challengeNew", "challengeAccepted", "challengeDeclined" ].indexOf(kind) > -1) {
 
-      var url = (data.gameId) ? Router.routes.match.url({_id: data.gameId}) : Router.routes.lobby.url();
+      var url = (data.gameId) ? Router.routes.match.url({_id: data.gameId}) : Router.routes.lobby.url({}, {query: {challenges: "open" }});
 
       return Herald.createNotification(this._id, {
         courier: kind,

--- a/lib/notifications.js
+++ b/lib/notifications.js
@@ -68,6 +68,19 @@ Herald.addCourier('challengeNew', {
 Herald.addCourier('challengeAccepted', {
   media: {
     onsite: {},
+    webNotification: {
+      title: "Challenge accepted",
+      body: function() {
+        var recipient = Meteor.users.findOne(this.data.recipientId);
+
+        return recipient.username+" accepted your game challenge. Click to go to the game.";
+      },
+      icon: "/chat.icon",
+      onRun: function() {
+        // only run if page is hidden
+        return document.hidden ? this.run() : this.stop();
+      }
+    },
     email: {
       emailRunner: function(user) {
         var to = user.getEmail();

--- a/lib/notifications.js
+++ b/lib/notifications.js
@@ -25,6 +25,21 @@ Herald.addCourier('yourTurn', {
 Herald.addCourier('challengeNew', {
   media: {
     onsite: {},
+    webNotification: {
+      title: "New challenge",
+      body: function() {
+        var challenger = Meteor.users.findOne(this.data.senderId);
+        var gameData = this.data.gameData;
+        var size = gameData.size + "x" + gameData.size;
+
+        return "You've received a new "+size+" challenge from "+challenger.username+". Click to respond.";
+      },
+      icon: "/chat.icon",
+      onRun: function() {
+        // only run if page is hidden
+        return document.hidden ? this.run() : this.stop();
+      }
+    },
     email: {
       emailRunner: function(user) {
         var to = user.getEmail();

--- a/lib/router.js
+++ b/lib/router.js
@@ -10,7 +10,16 @@ Router.configure({
   progress: false,
 });
 
-Router.route('/', { name: 'lobby', progress: true}); // index.html
+Router.route('/', {
+  name: 'lobby',
+  progress: true,
+  onBeforeAction: function() {
+    if (this.params.query.challenges === 'open') {
+      Session.set("challengeMenuOpen", true);
+      this.redirect("lobby");
+    } else this.next();
+  },
+}); // index.html
 Router.route('/:username', {
 	onBeforeAction: function(){
 		var username = this.params.username;


### PR DESCRIPTION
* People now get web notifications for received and accepted challenges.
* Put `?challenge=open` in lobby url to programmatically open the challenge menu (for notification links, etc)

Resolves #185.